### PR TITLE
[BREAKING CHANGE] Convert to Typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ out/
 system-test/secrets.js
 system-test/*key.json
 *.lock
+build/
+.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1925,6 +1925,12 @@
         "samsam": "1.3.0"
       }
     },
+    "@types/arrify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/arrify/-/arrify-1.0.4.tgz",
+      "integrity": "sha512-63nK8r8jvEVJ1r0ENaY9neB1wDzPHFYAzKiIxPawuzcijEX8XeOywwPL8fkSCwiTIYop9MSh+TKy9L2ZzTXV6g==",
+      "dev": true
+    },
     "@types/caseless": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
@@ -1938,6 +1944,12 @@
         "@types/node": "*"
       }
     },
+    "@types/extend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.0.tgz",
+      "integrity": "sha512-Eo8NQCbgjlMPQarlFAE3vpyCvFda4dg1Ob5ZJb6BJI9x4NAZVWowyMNB8GJJDgDI4lr2oqiQvXlPB0Fn1NoXnQ==",
+      "dev": true
+    },
     "@types/form-data": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
@@ -1946,10 +1958,52 @@
         "@types/node": "*"
       }
     },
+    "@types/is": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/is/-/is-0.0.20.tgz",
+      "integrity": "sha512-013vMJ4cpYRm1GavhN8HqSKRWD/txm2BLcy/Qw9hAoSNJwp60ezLH+/QlX3JouGTPJcmxvbDUWGANxjS52jRaw==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.109",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.109.tgz",
+      "integrity": "sha512-hop8SdPUEzbcJm6aTsmuwjIYQo1tqLseKCM+s2bBqTU2gErwI4fE+aqUVOlscPSQbKHKgtMMPoC+h4AIGOJYvw==",
+      "dev": true
+    },
+    "@types/lodash.flatten": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@types/lodash.flatten/-/lodash.flatten-4.4.3.tgz",
+      "integrity": "sha512-K9KM5vObObrjcPE/shM3HKtGLc66QgxU0W6nMaevNcOyR92oOKDPHmNE7C7IYoP8fbhLxI03Gg3Cc44HD72p9Q==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.groupby": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@types/lodash.groupby/-/lodash.groupby-4.6.3.tgz",
+      "integrity": "sha512-xin4XfinWVapQvSGPCmjUIv/6t8ZkFHoH4c0ppx8Yq4zEYF32H8L9rkPvxCx+JKs+FXkfbDY7NyYF7ETJkfDvQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/mocha": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.1.tgz",
+      "integrity": "sha512-dOrgprHnkDaj1pmrwdcMAf0QRNQzqTB5rxJph+iIQshSmIvtgRqJ0nim8u1vvXU8iOXZrH96+M46JDFTPLingA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "10.3.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.2.tgz",
       "integrity": "sha512-9NfEUDp3tgRhmoxzTpTo+lq+KIVFxZahuRX0LHF/9IzKHaWuoWsIrrJ61zw5cnnlGINX8lqJzXYfQTOICS5Q+A=="
+    },
+    "@types/proxyquire": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@types/proxyquire/-/proxyquire-1.3.28.tgz",
+      "integrity": "sha512-SQaNzWQ2YZSr7FqAyPPiA3FYpux2Lqh3HWMZQk47x3xbMCqgC/w0dY3dw9rGqlweDDkrySQBcaScXWeR+Yb11Q==",
+      "dev": true
     },
     "@types/request": {
       "version": "2.47.0",
@@ -1966,6 +2020,15 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ=="
+    },
+    "@types/uuid": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
+      "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "acorn": {
       "version": "5.6.2",
@@ -3076,6 +3139,25 @@
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
+    "clang-format": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.2.3.tgz",
+      "integrity": "sha512-x90Hac4ERacGDcZSvHKK58Ga0STuMD+Doi5g0iG2zf7wlJef5Huvhs/3BvMRFxwRYyYSdl6mpQNrtfMxE8MQzw==",
+      "dev": true,
+      "requires": {
+        "async": "^1.5.2",
+        "glob": "^7.0.0",
+        "resolve": "^1.1.6"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
+    },
     "clean-stack": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
@@ -3420,6 +3502,16 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      }
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -5114,6 +5206,169 @@
         "pify": "^3.0.0"
       }
     },
+    "gts": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/gts/-/gts-0.6.0.tgz",
+      "integrity": "sha512-MCh3HNzLA1zvnW8lStH58n6U7SaGCJwd0Y2fUWJklHdtpMB9zaGe8SR7l0DqqPf+t0hNoFu2KmRFxHBnkeeKrA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "clang-format": "1.2.3",
+        "inquirer": "^5.2.0",
+        "meow": "^5.0.0",
+        "pify": "^3.0.0",
+        "rimraf": "^2.6.2",
+        "tslint": "^5.9.1",
+        "update-notifier": "^2.5.0",
+        "write-file-atomic": "^2.3.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
+          }
+        },
+        "inquirer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+          "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.1.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^5.5.2",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+          "dev": true
+        },
+        "meow": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+          "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0",
+            "yargs-parser": "^10.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "redent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+          "dev": true,
+          "requires": {
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
+          }
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.0.0.tgz",
+          "integrity": "sha512-+DHejWujTVYeMHLff8U96rLc4uE4Emncoftvn5AjhB1Jw1pWxLzgBUT/WYbPrHmy6YPEBTZQx5myHhVcuuu64g==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
+    },
     "handlebars": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
@@ -6313,11 +6568,6 @@
         "estraverse": "^4.0.0"
       }
     },
-    "methmeth": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/methmeth/-/methmeth-1.1.0.tgz",
-      "integrity": "sha1-6AomYY5S9cQiKGG7dIUQvRDikIk="
-    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -6389,6 +6639,16 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
+    },
+    "minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -9227,11 +9487,6 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
-    "propprop": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/propprop/-/propprop-0.3.1.tgz",
-      "integrity": "sha1-oEmjVouJZEAGfRXY7J8zc15XAXg="
-    },
     "proxyquire": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.0.1.tgz",
@@ -9279,6 +9534,12 @@
         "object-assign": "^4.1.0",
         "strict-uri-encode": "^1.0.0"
       }
+    },
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+      "dev": true
     },
     "randomatic": {
       "version": "3.0.0",
@@ -9676,6 +9937,23 @@
       "dev": true,
       "requires": {
         "rx-lite": "*"
+      }
+    },
+    "rxjs": {
+      "version": "5.5.11",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
+      "integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {
@@ -10217,6 +10495,52 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
+    "tslib": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.2.tgz",
+      "integrity": "sha512-AVP5Xol3WivEr7hnssHDsaM+lVrVXWUvd1cfXTRkTj80b//6g2wIFEH6hZG0muGZRnHGrfttpdzRk3YlBkWjKw==",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.10.0.tgz",
+      "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.22.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.12.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
+        }
+      }
+    },
+    "tsutils": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.1.tgz",
+      "integrity": "sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -10256,6 +10580,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.1.tgz",
+      "integrity": "sha512-h6pM2f/GDchCFlldnriOhs1QHuwbnmj6/v7499eMHqPeW4V2G0elua2eIc2nu8v2NdHV0Gm+tzX83Hr6nUFjQA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "node": ">=6.0.0"
   },
   "repository": "googleapis/nodejs-dns",
-  "main": "./src/index.js",
+  "main": "build/src/index.js",
+  "types": "build/src/index.d.ts",
   "files": [
-    "src",
+    "build/src",
     "AUTHORS",
     "CONTRIBUTORS",
     "LICENSE"
@@ -41,16 +42,23 @@
     "greenkeeper[bot] <greenkeeper[bot]@users.noreply.github.com>"
   ],
   "scripts": {
-    "cover": "nyc --reporter=lcov mocha --require intelli-espower-loader test/*.js && nyc report",
+    "cover": "nyc --reporter=lcov mocha --require intelli-espower-loader build/test && nyc report",
     "docs": "repo-tools exec -- jsdoc -c .jsdoc.js",
     "generate-scaffolding": "repo-tools generate all && repo-tools generate lib_samples_readme -l samples/ --config ../.cloud-repo-tools.json",
-    "lint": "repo-tools lint --cmd eslint -- src/ samples/ system-test/ test/",
-    "prettier": "repo-tools exec -- prettier --write src/*.js src/*/*.js samples/*.js samples/*/*.js test/*.js test/*/*.js system-test/*.js system-test/*/*.js",
+    "lint": "repo-tools lint --cmd eslint -- samples/",
+    "prettier": "repo-tools exec -- prettier --write samples/*.js samples/*/*.js",
     "publish-module": "node ../../scripts/publish.js dns",
-    "test-no-cover": "repo-tools test run --cmd mocha -- test/*.js --no-timeouts",
+    "test-no-cover": "repo-tools test run --cmd mocha -- build/test",
     "test": "repo-tools test run --cmd npm -- run cover",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
-    "system-test": "repo-tools test run --cmd mocha -- system-test/*.js --timeout 600000"
+    "system-test": "repo-tools test run --cmd mocha -- build/system-test --timeout 600000",
+    "check": "gts check",
+    "clean": "gts clean",
+    "compile": "tsc -p .",
+    "fix": "gts fix",
+    "prepare": "npm run compile",
+    "pretest": "npm run compile",
+    "presystem-test": "npm run compile"
   },
   "dependencies": {
     "@google-cloud/common": "^0.20.0",
@@ -60,19 +68,25 @@
     "is": "^3.2.1",
     "lodash.flatten": "^4.4.0",
     "lodash.groupby": "^4.6.0",
-    "methmeth": "^1.1.0",
-    "propprop": "^0.3.1",
     "string-format-obj": "^1.1.1"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^2.3.0",
+    "@types/arrify": "^1.0.4",
+    "@types/extend": "^3.0.0",
+    "@types/is": "0.0.20",
+    "@types/lodash.flatten": "^4.4.3",
+    "@types/lodash.groupby": "^4.6.3",
+    "@types/mocha": "^5.2.1",
+    "@types/proxyquire": "^1.3.28",
+    "@types/uuid": "^3.4.3",
     "async": "^2.6.1",
     "codecov": "^3.0.2",
     "eslint": "^4.19.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-prettier": "^2.6.0",
-    "extend": "^3.0.1",
+    "gts": "^0.6.0",
     "ink-docstrap": "^1.3.2",
     "intelli-espower-loader": "^1.0.1",
     "jsdoc": "^3.5.5",
@@ -82,6 +96,7 @@
     "prettier": "^1.13.5",
     "proxyquire": "^2.0.1",
     "tmp": "^0.0.33",
+    "typescript": "~2.9.1",
     "uuid": "^3.2.1"
   }
 }

--- a/src/change.ts
+++ b/src/change.ts
@@ -16,8 +16,8 @@
 
 'use strict';
 
-var common = require('@google-cloud/common');
-var util = require('util');
+import * as common from '@google-cloud/common';
+import * as util from 'util';
 
 /**
  * @class

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@
 import * as common from '@google-cloud/common';
 import extend from 'extend';
 import * as util from 'util';
+import is from 'is';
+import arrify from 'arrify';
 
 var Zone = require('./zone.js');
 
@@ -233,7 +235,7 @@ DNS.prototype.createZone = function(name, config, callback) {
 DNS.prototype.getZones = function(query, callback) {
   var self = this;
 
-  if (typeof query === 'function') {
+  if (is.fn(query)) {
     callback = query;
     query = {};
   }
@@ -249,7 +251,7 @@ DNS.prototype.getZones = function(query, callback) {
         return;
       }
 
-      var zones = [...resp.managedZones].map(function(zone) {
+      var zones = arrify(resp.managedZones).map(function(zone) {
         var zoneInstance = self.zone(zone.name);
         zoneInstance.metadata = zone;
         return zoneInstance;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,9 @@
 
 'use strict';
 
-var arrify = require('arrify');
-var common = require('@google-cloud/common');
-var extend = require('extend');
-var is = require('is');
-var util = require('util');
+import * as common from '@google-cloud/common';
+import extend from 'extend';
+import * as util from 'util';
 
 var Zone = require('./zone.js');
 
@@ -79,10 +77,6 @@ var Zone = require('./zone.js');
  * Full quickstart example:
  */
 function DNS(options) {
-  if (!(this instanceof DNS)) {
-    return new DNS(options);
-  }
-
   options = common.util.normalizeArguments(this, options);
 
   var config = {
@@ -91,7 +85,7 @@ function DNS(options) {
       'https://www.googleapis.com/auth/ndev.clouddns.readwrite',
       'https://www.googleapis.com/auth/cloud-platform',
     ],
-    packageJson: require('../package.json'),
+    packageJson: require('../../package.json'),
   };
 
   common.Service.call(this, config, options);
@@ -239,7 +233,7 @@ DNS.prototype.createZone = function(name, config, callback) {
 DNS.prototype.getZones = function(query, callback) {
   var self = this;
 
-  if (is.fn(query)) {
+  if (typeof query === 'function') {
     callback = query;
     query = {};
   }
@@ -255,7 +249,7 @@ DNS.prototype.getZones = function(query, callback) {
         return;
       }
 
-      var zones = arrify(resp.managedZones).map(function(zone) {
+      var zones = [...resp.managedZones].map(function(zone) {
         var zoneInstance = self.zone(zone.name);
         zoneInstance.metadata = zone;
         return zoneInstance;
@@ -351,7 +345,7 @@ common.util.promisifyAll(DNS, {
  * @see Zone
  * @type {Constructor}
  */
-DNS.Zone = Zone;
+(DNS as any).Zone = Zone;
 
 /**
  * The default export of the `@google-cloud/dns` package is the {@link DNS}

--- a/src/record.ts
+++ b/src/record.ts
@@ -16,10 +16,10 @@
 
 'use strict';
 
-var arrify = require('arrify');
-var common = require('@google-cloud/common');
-var extend = require('extend');
-var format = require('string-format-obj');
+import {util} from '@google-cloud/common';
+import extend from 'extend';
+import arrify from 'arrify';
+const format = require('string-format-obj');
 
 /**
  * Create a Resource Record object.
@@ -88,7 +88,7 @@ function Record(zone, type, metadata) {
  *     based on the type of record.
  * @returns {Record}
  */
-Record.fromZoneRecord_ = function(zone, type, bindData) {
+(Record as any).fromZoneRecord_ = function(zone, type, bindData) {
   var typeToZoneFormat = {
     a: '{ip}',
     aaaa: '{ip}',
@@ -201,7 +201,7 @@ Record.prototype.toString = function() {
  * All async methods (except for streams) will return a Promise in the event
  * that a callback is omitted.
  */
-common.util.promisifyAll(Record, {
+util.promisifyAll(Record, {
   exclude: ['toJSON', 'toString'],
 });
 

--- a/src/zone.ts
+++ b/src/zone.ts
@@ -16,17 +16,15 @@
 
 'use strict';
 
-var arrify = require('arrify');
-var common = require('@google-cloud/common');
-var exec = require('methmeth');
-var extend = require('extend');
-var flatten = require('lodash.flatten');
-var fs = require('fs');
-var groupBy = require('lodash.groupby');
-var is = require('is');
-var prop = require('propprop');
-var util = require('util');
-var zonefile = require('dns-zonefile');
+import * as common from '@google-cloud/common';
+import extend from 'extend';
+import arrify from 'arrify';
+import flatten from 'lodash.flatten';
+import * as fs from 'fs';
+import groupBy from 'lodash.groupby';
+import is from 'is';
+import * as util from 'util';
+const zonefile = require('dns-zonefile');
 
 var Change = require('./change.js');
 var Record = require('./record.js');
@@ -347,8 +345,8 @@ Zone.prototype.createChange = function(config, callback) {
 
   var body = extend(
     {
-      additions: groupByType(arrify(config.add).map(exec('toJSON'))),
-      deletions: groupByType(arrify(config.delete).map(exec('toJSON'))),
+      additions: groupByType(arrify(config.add).map(x => x.toJSON())),
+      deletions: groupByType(arrify(config.delete).map(x => x.toJSON())),
     },
     config
   );
@@ -358,7 +356,7 @@ Zone.prototype.createChange = function(config, callback) {
   function groupByType(changes) {
     changes = groupBy(changes, 'type');
 
-    var changesArray = [];
+    var changesArray: {}[] = [];
 
     for (var recordType in changes) {
       var recordsByName = groupBy(changes[recordType], 'name');
@@ -369,7 +367,7 @@ Zone.prototype.createChange = function(config, callback) {
 
         if (records.length > 1) {
           // Combine the `rrdatas` values from all records of the same type.
-          templateRecord.rrdatas = flatten(records.map(prop('rrdatas')));
+          templateRecord.rrdatas = flatten(records.map(x => x.rrdatas));
         }
 
         changesArray.push(templateRecord);
@@ -656,7 +654,7 @@ Zone.prototype.export = function(localPath, callback) {
       return;
     }
 
-    var stringRecords = records.map(exec('toString')).join('\n');
+    var stringRecords = records.map(x => x.toString()).join('\n');
 
     fs.writeFile(localPath, stringRecords, 'utf-8', function(err) {
       callback(err || null);
@@ -1036,7 +1034,7 @@ Zone.prototype.import = function(localPath, callback) {
     delete parsedZonefile.$ttl;
 
     var recordTypes = Object.keys(parsedZonefile);
-    var recordsToCreate = [];
+    var recordsToCreate: {}[] = [];
 
     recordTypes.forEach(function(recordType) {
       var recordTypeSet = arrify(parsedZonefile[recordType]);

--- a/system-test/.eslintrc.yml
+++ b/system-test/.eslintrc.yml
@@ -1,6 +1,0 @@
----
-env:
-  mocha: true
-rules:
-  node/no-unpublished-require: off
-  no-console: off

--- a/system-test/dns.ts
+++ b/system-test/dns.ts
@@ -16,15 +16,14 @@
 
 'use strict';
 
-var assert = require('assert');
-var async = require('async');
-var exec = require('methmeth');
-var format = require('string-format-obj');
-var fs = require('fs');
-var tmp = require('tmp');
-var uuid = require('uuid');
+import assert from 'assert';
+import async from 'async';
+import * as fs from 'fs';
+import tmp from 'tmp';
+import uuid from 'uuid';
+const format = require('string-format-obj');
 
-var DNS = require('../');
+var DNS = require('../../');
 
 var dns = new DNS();
 var DNS_DOMAIN = process.env.GCLOUD_TESTS_DNS_DOMAIN;
@@ -120,15 +119,11 @@ var DNS_DOMAIN = process.env.GCLOUD_TESTS_DNS_DOMAIN;
         done(err);
         return;
       }
-
-      async.each(zones, exec('delete', {force: true}), function(err) {
-        if (err) {
-          done(err);
-          return;
-        }
-
+      Promise.all(zones.map(z => {
+        return z.delete({force: true});
+      })).then(() => {
         ZONE.create({dnsName: DNS_DOMAIN}, done);
-      });
+      }, done);
     });
   });
 
@@ -222,7 +217,6 @@ var DNS_DOMAIN = process.env.GCLOUD_TESTS_DNS_DOMAIN;
       tmp.setGracefulCleanup();
       tmp.file(function tempFileCreated(err, tmpFilename) {
         assert.ifError(err);
-
         async.series(
           [
             function(next) {

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,5 +1,0 @@
----
-env:
-  mocha: true
-rules:
-  node/no-unpublished-require: off

--- a/test/change.ts
+++ b/test/change.ts
@@ -16,12 +16,11 @@
 
 'use strict';
 
-var assert = require('assert');
-var extend = require('extend');
-var nodeutil = require('util');
-var proxyquire = require('proxyquire');
-var ServiceObject = require('@google-cloud/common').ServiceObject;
-var util = require('@google-cloud/common').util;
+import assert from 'assert';
+import extend from 'extend';
+import * as nodeutil from 'util';
+import proxyquire from 'proxyquire';
+import {ServiceObject, util} from '@google-cloud/common';
 
 var promisified = false;
 var fakeUtil = extend({}, util, {

--- a/test/index.ts
+++ b/test/index.ts
@@ -16,13 +16,12 @@
 
 'use strict';
 
-var arrify = require('arrify');
-var assert = require('assert');
-var extend = require('extend');
-var nodeutil = require('util');
-var proxyquire = require('proxyquire');
-var Service = require('@google-cloud/common').Service;
-var util = require('@google-cloud/common').util;
+import assert from 'assert';
+import extend from 'extend';
+import * as nodeutil from 'util';
+import proxyquire from 'proxyquire';
+import arrify from 'arrify';
+import {Service, util} from '@google-cloud/common';
 
 var extended = false;
 var fakePaginator = {
@@ -73,7 +72,7 @@ describe('DNS', function() {
   var PROJECT_ID = 'project-id';
 
   before(function() {
-    DNS = proxyquire('../', {
+    DNS = proxyquire('../src', {
       '@google-cloud/common': {
         Service: FakeService,
         paginator: fakePaginator,
@@ -103,12 +102,6 @@ describe('DNS', function() {
       assert(promisified);
     });
 
-    it('should work without new', function() {
-      assert.doesNotThrow(function() {
-        DNS({projectId: PROJECT_ID});
-      });
-    });
-
     it('should normalize the arguments', function() {
       var normalizeArgumentsCalled = false;
       var options = {};
@@ -134,7 +127,7 @@ describe('DNS', function() {
         'https://www.googleapis.com/auth/ndev.clouddns.readwrite',
         'https://www.googleapis.com/auth/cloud-platform',
       ]);
-      assert.deepEqual(calledWith.packageJson, require('../package.json'));
+      assert.deepEqual(calledWith.packageJson, require('../../package.json'));
     });
   });
 

--- a/test/record.ts
+++ b/test/record.ts
@@ -16,10 +16,10 @@
 
 'use strict';
 
-var assert = require('assert');
-var extend = require('extend');
-var proxyquire = require('proxyquire');
-var util = require('@google-cloud/common').util;
+import assert from 'assert';
+import extend from 'extend';
+import proxyquire from 'proxyquire';
+import {util} from '@google-cloud/common';
 
 var promisified = false;
 var fakeUtil = extend({}, util, {

--- a/test/zone.ts
+++ b/test/zone.ts
@@ -16,17 +16,14 @@
 
 'use strict';
 
-var arrify = require('arrify');
-var assert = require('assert');
-var exec = require('methmeth');
-var extend = require('extend');
-var flatten = require('lodash.flatten');
-var nodeutil = require('util');
-var prop = require('propprop');
-var proxyquire = require('proxyquire');
-var ServiceObject = require('@google-cloud/common').ServiceObject;
-var util = require('@google-cloud/common').util;
-var uuid = require('uuid');
+import assert from 'assert';
+import extend from 'extend';
+import flatten from 'lodash.flatten';
+import * as nodeutil from 'util';
+import arrify from 'arrify';
+import proxyquire from 'proxyquire';
+import uuid from 'uuid';
+import {ServiceObject, util} from '@google-cloud/common';
 
 var promisified = false;
 var fakeUtil = extend({}, util, {
@@ -65,7 +62,7 @@ function FakeChange() {
 function FakeRecord() {
   this.calledWith_ = arguments;
 }
-FakeRecord.fromZoneRecord_ = function() {
+(FakeRecord as any).fromZoneRecord_ = function() {
   var record = new FakeRecord();
   record.calledWith_ = arguments;
   return record;
@@ -196,7 +193,7 @@ describe('Zone', function() {
   });
 
   describe('createChange', function() {
-    function generateRecord(recordJson) {
+    function generateRecord(recordJson?) {
       recordJson = extend(
         {
           name: uuid.v1(),
@@ -222,7 +219,7 @@ describe('Zone', function() {
     it('should parse and rename add to additions', function(done) {
       var recordsToAdd = [generateRecord(), generateRecord()];
 
-      var expectedAdditions = recordsToAdd.map(exec('toJSON'));
+      var expectedAdditions = recordsToAdd.map(x => x.toJSON());
 
       zone.request = function(reqOpts) {
         assert.strictEqual(reqOpts.json.add, undefined);
@@ -236,7 +233,7 @@ describe('Zone', function() {
     it('should parse and rename delete to deletions', function(done) {
       var recordsToDelete = [generateRecord(), generateRecord()];
 
-      var expectedDeletions = recordsToDelete.map(exec('toJSON'));
+      var expectedDeletions = recordsToDelete.map(x => x.toJSON());
 
       zone.request = function(reqOpts) {
         assert.strictEqual(reqOpts.json.delete, undefined);
@@ -255,7 +252,7 @@ describe('Zone', function() {
 
       zone.request = function(reqOpts) {
         var expectedRRDatas = flatten(
-          recordsToAdd.map(exec('toJSON')).map(prop('rrdatas'))
+          recordsToAdd.map(x => x.toJSON()).map(x => x.rrdatas)
         );
 
         assert.deepStrictEqual(reqOpts.json.additions, [
@@ -829,7 +826,7 @@ describe('Zone', function() {
 
     describe('success', function() {
       var recordType = 'ns';
-      var parsedZonefile = {};
+      var parsedZonefile: any = {};
 
       beforeEach(function() {
         parsedZonefile = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build",
+    "noImplicitAny": false,
+    "noImplicitThis": false
+  },
+  "include": [
+    "src/*.ts",
+    "test/*.ts",
+    "system-test/*.ts"
+  ]
+}


### PR DESCRIPTION
BREAKING CHANGE: This is a breaking change.  In previous versions of this npm module, a `DNS` instance was automatically created by requiring the module.  Moving forward, the `DNS` object must be instantiated:

```js
const DNS = require('@google-cloud/dns');
const dns = new DNS();
```