### PR TITLE
chore: assert.deelEqual => assert.deepStrictEqual

### DIFF
--- a/system-test/dns.js
+++ b/system-test/dns.js
@@ -259,7 +259,7 @@ const DNS_DOMAIN = process.env.GCLOUD_TESTS_DNS_DOMAIN;
 
           const addition = change.metadata.additions[0];
           delete addition.kind;
-          assert.deepEqual(addition, record.toJSON());
+          assert.deepStrictEqual(addition, record.toJSON());
 
           done();
         });
@@ -285,7 +285,7 @@ const DNS_DOMAIN = process.env.GCLOUD_TESTS_DNS_DOMAIN;
 
             delete metadata.status;
             delete expectedMetadata.status;
-            assert.deepEqual(metadata, expectedMetadata);
+            assert.deepStrictEqual(metadata, expectedMetadata);
 
             done();
           });
@@ -363,8 +363,8 @@ const DNS_DOMAIN = process.env.GCLOUD_TESTS_DNS_DOMAIN;
             const deleted = change.metadata.deletions[0].rrdatas;
             const added = change.metadata.additions[0].rrdatas;
 
-            assert.deepEqual(deleted, originalData);
-            assert.deepEqual(added, newRecord.data);
+            assert.deepStrictEqual(deleted, originalData);
+            assert.deepStrictEqual(added, newRecord.data);
 
             done();
           });

--- a/test/change.js
+++ b/test/change.js
@@ -72,7 +72,7 @@ describe('Change', function() {
       assert.strictEqual(calledWith.parent, ZONE);
       assert.strictEqual(calledWith.baseUrl, '/changes');
       assert.strictEqual(calledWith.id, CHANGE_ID);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         exists: true,
         get: true,
         getMetadata: true,

--- a/test/index.js
+++ b/test/index.js
@@ -34,7 +34,7 @@ const fakePaginator = {
     extended = true;
     methods = arrify(methods);
     assert.strictEqual(Class.name, 'DNS');
-    assert.deepEqual(methods, ['getZones']);
+    assert.deepStrictEqual(methods, ['getZones']);
   },
   streamify: function(methodName) {
     return methodName;
@@ -57,7 +57,7 @@ const fakeUtil = extend({}, util, {
     }
 
     promisified = true;
-    assert.deepEqual(options.exclude, ['zone']);
+    assert.deepStrictEqual(options.exclude, ['zone']);
   },
 });
 const originalFakeUtil = extend(true, {}, fakeUtil);
@@ -130,11 +130,11 @@ describe('DNS', function() {
 
       const baseUrl = 'https://www.googleapis.com/dns/v1';
       assert.strictEqual(calledWith.baseUrl, baseUrl);
-      assert.deepEqual(calledWith.scopes, [
+      assert.deepStrictEqual(calledWith.scopes, [
         'https://www.googleapis.com/auth/ndev.clouddns.readwrite',
         'https://www.googleapis.com/auth/cloud-platform',
       ]);
-      assert.deepEqual(calledWith.packageJson, require('../package.json'));
+      assert.deepStrictEqual(calledWith.packageJson, require('../package.json'));
     });
   });
 
@@ -187,7 +187,7 @@ describe('DNS', function() {
           name: zoneName,
           description: '',
         });
-        assert.deepEqual(reqOpts.json, expectedBody);
+        assert.deepStrictEqual(reqOpts.json, expectedBody);
 
         done();
       };
@@ -343,9 +343,9 @@ describe('DNS', function() {
           assert.ifError(err);
 
           // Check the original query wasn't modified.
-          assert.deepEqual(query, originalQuery);
+          assert.deepStrictEqual(query, originalQuery);
 
-          assert.deepEqual(
+          assert.deepStrictEqual(
             nextQuery,
             extend({}, query, {
               pageToken: apiResponseWithNextPageToken.nextPageToken,

--- a/test/index.js
+++ b/test/index.js
@@ -134,7 +134,10 @@ describe('DNS', function() {
         'https://www.googleapis.com/auth/ndev.clouddns.readwrite',
         'https://www.googleapis.com/auth/cloud-platform',
       ]);
-      assert.deepStrictEqual(calledWith.packageJson, require('../package.json'));
+      assert.deepStrictEqual(
+        calledWith.packageJson,
+        require('../package.json')
+      );
     });
   });
 

--- a/test/record.js
+++ b/test/record.js
@@ -29,7 +29,7 @@ const fakeUtil = extend({}, util, {
     }
 
     promisified = true;
-    assert.deepEqual(options.exclude, ['toJSON', 'toString']);
+    assert.deepStrictEqual(options.exclude, ['toJSON', 'toString']);
   },
 });
 
@@ -111,7 +111,7 @@ describe('Record', function() {
         const record = Record.fromZoneRecord_(ZONE, 'a', aRecord);
 
         assert.strictEqual(record.type, 'A');
-        assert.deepEqual(record.metadata.data, expectedData);
+        assert.deepStrictEqual(record.metadata.data, expectedData);
         assert.strictEqual(record.metadata.name, aRecord.name);
         assert.strictEqual(record.metadata.ttl, aRecord.ttl);
       });
@@ -312,7 +312,7 @@ describe('Record', function() {
       });
       delete expectedRecord.data;
 
-      assert.deepEqual(record.toJSON(), expectedRecord);
+      assert.deepStrictEqual(record.toJSON(), expectedRecord);
     });
   });
 

--- a/test/zone.js
+++ b/test/zone.js
@@ -35,7 +35,7 @@ const fakeUtil = extend({}, util, {
     }
 
     promisified = true;
-    assert.deepEqual(options.exclude, ['change', 'record']);
+    assert.deepStrictEqual(options.exclude, ['change', 'record']);
   },
 });
 
@@ -87,7 +87,7 @@ const fakePaginator = {
     extended = true;
     methods = arrify(methods);
     assert.strictEqual(Class.name, 'Zone');
-    assert.deepEqual(methods, ['getChanges', 'getRecords']);
+    assert.deepStrictEqual(methods, ['getChanges', 'getRecords']);
   },
   streamify: function(methodName) {
     return methodName;
@@ -160,7 +160,7 @@ describe('Zone', function() {
       assert.strictEqual(calledWith.parent, dnsInstance);
       assert.strictEqual(calledWith.baseUrl, '/managedZones');
       assert.strictEqual(calledWith.id, ZONE_NAME);
-      assert.deepEqual(calledWith.methods, {
+      assert.deepStrictEqual(calledWith.methods, {
         create: true,
         exists: true,
         get: true,
@@ -225,7 +225,7 @@ describe('Zone', function() {
 
       zone.request = function(reqOpts) {
         assert.strictEqual(reqOpts.json.add, undefined);
-        assert.deepEqual(reqOpts.json.additions, expectedAdditions);
+        assert.deepStrictEqual(reqOpts.json.additions, expectedAdditions);
         done();
       };
 
@@ -239,7 +239,7 @@ describe('Zone', function() {
 
       zone.request = function(reqOpts) {
         assert.strictEqual(reqOpts.json.delete, undefined);
-        assert.deepEqual(reqOpts.json.deletions, expectedDeletions);
+        assert.deepStrictEqual(reqOpts.json.deletions, expectedDeletions);
         done();
       };
 
@@ -370,7 +370,7 @@ describe('Zone', function() {
       const recordsToDelete = 'ns';
 
       zone.deleteRecordsByType_ = function(types, callback) {
-        assert.deepEqual(types, [recordsToDelete]);
+        assert.deepStrictEqual(types, [recordsToDelete]);
         callback();
       };
 
@@ -381,7 +381,7 @@ describe('Zone', function() {
       const recordsToDelete = {a: 'b', c: 'd'};
 
       zone.createChange = function(options, callback) {
-        assert.deepEqual(options.delete, [recordsToDelete]);
+        assert.deepStrictEqual(options.delete, [recordsToDelete]);
         callback();
       };
 
@@ -450,7 +450,7 @@ describe('Zone', function() {
 
       it('should delete non-NS and non-SOA records', function(done) {
         zone.deleteRecords = function(recordsToDelete, callback) {
-          assert.deepEqual(recordsToDelete, expectedRecordsToDelete);
+          assert.deepStrictEqual(recordsToDelete, expectedRecordsToDelete);
           callback();
         };
 
@@ -570,7 +570,7 @@ describe('Zone', function() {
   describe('getChanges', function() {
     it('should accept only a callback', function(done) {
       zone.request = function(reqOpts) {
-        assert.deepEqual(reqOpts.qs, {});
+        assert.deepStrictEqual(reqOpts.qs, {});
         done();
       };
 
@@ -649,7 +649,7 @@ describe('Zone', function() {
         zone.getChanges({}, function(err, changes, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(nextQuery, expectedNextQuery);
+          assert.deepStrictEqual(nextQuery, expectedNextQuery);
 
           done();
         });
@@ -729,7 +729,7 @@ describe('Zone', function() {
         zone.getRecords({}, function(err, records, nextQuery) {
           assert.ifError(err);
 
-          assert.deepEqual(nextQuery, expectedNextQuery);
+          assert.deepStrictEqual(nextQuery, expectedNextQuery);
 
           done();
         });


### PR DESCRIPTION
deepEqual is deprecated. Use deepStrictEqual instead