### PR TITLE
Use teeny-request

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,36 +53,37 @@
     "system-test": "mocha system-test/*.js --timeout 600000"
   },
   "dependencies": {
-    "@google-cloud/common": "^0.22.0",
+    "@google-cloud/common": "^0.23.0",
     "@google-cloud/paginator": "^0.1.0",
     "@google-cloud/promisify": "^0.3.0",
     "arrify": "^1.0.1",
     "dns-zonefile": "0.2.2",
-    "extend": "^3.0.0",
+    "extend": "^3.0.2",
     "is": "^3.2.1",
     "lodash.flatten": "^4.4.0",
     "lodash.groupby": "^4.6.0",
     "methmeth": "^1.1.0",
     "propprop": "^0.3.1",
-    "string-format-obj": "^1.1.1"
+    "string-format-obj": "^1.1.1",
+    "teeny-request": "^3.6.0"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "^2.3.0",
+    "@google-cloud/nodejs-repo-tools": "^2.3.3",
     "async": "^2.6.1",
-    "codecov": "^3.0.2",
-    "eslint": "^5.0.0",
-    "eslint-config-prettier": "^3.0.0",
-    "eslint-plugin-node": "^7.0.0",
-    "eslint-plugin-prettier": "^2.6.0",
+    "codecov": "^3.0.4",
+    "eslint": "^5.5.0",
+    "eslint-config-prettier": "^3.0.1",
+    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-prettier": "^2.6.2",
     "ink-docstrap": "^1.3.2",
     "intelli-espower-loader": "^1.0.1",
     "jsdoc": "^3.5.5",
     "mocha": "^5.2.0",
-    "nyc": "^13.0.0",
-    "power-assert": "^1.5.0",
-    "prettier": "^1.13.5",
-    "proxyquire": "^2.0.1",
+    "nyc": "^13.0.1",
+    "power-assert": "^1.6.0",
+    "prettier": "^1.14.2",
+    "proxyquire": "^2.1.0",
     "tmp": "^0.0.33",
-    "uuid": "^3.2.1"
+    "uuid": "^3.3.2"
   }
 }

--- a/src/change.js
+++ b/src/change.js
@@ -18,6 +18,7 @@
 
 const {ServiceObject} = require('@google-cloud/common');
 const {promisifyAll} = require('@google-cloud/promisify');
+const request = require('teeny-request');
 
 /**
  * @class
@@ -179,6 +180,7 @@ class Change extends ServiceObject {
        */
       id: id,
       methods: methods,
+      requestModule: request,
     });
   }
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ const arrify = require('arrify');
 const {Service} = require('@google-cloud/common');
 const {paginator} = require('@google-cloud/paginator');
 const {promisifyAll} = require('@google-cloud/promisify');
+const request = require('teeny-request');
 const extend = require('extend');
 const is = require('is');
 const util = require('util');
@@ -89,6 +90,7 @@ class DNS extends Service {
         'https://www.googleapis.com/auth/cloud-platform',
       ],
       packageJson: require('../package.json'),
+      requestModule: request,
     };
     super(config, options);
   }
@@ -274,8 +276,6 @@ class DNS extends Service {
     return new Zone(this, name);
   }
 }
-
-util.inherits(DNS, Service);
 
 /**
  * Get {@link Zone} objects for all of the zones in your project as

--- a/src/zone.js
+++ b/src/zone.js
@@ -20,6 +20,7 @@ const arrify = require('arrify');
 const {ServiceObject} = require('@google-cloud/common');
 const {paginator} = require('@google-cloud/paginator');
 const {promisifyAll} = require('@google-cloud/promisify');
+const request = require('teeny-request');
 const exec = require('methmeth');
 const extend = require('extend');
 const flatten = require('lodash.flatten');
@@ -211,6 +212,7 @@ class Zone extends ServiceObject {
       id: name,
       createMethod: dns.createZone.bind(dns),
       methods: methods,
+      requestModule: request,
     });
     /**
      * @name Zone#name


### PR DESCRIPTION
@fhinkel the system tests currently fail with this error:

```
dns
    1) "before all" hook
(node:39906) UnhandledPromiseRejectionWarning: TypeError: config.request.defaults is not a function
    at Util.makeRequest (/Users/beckwith/Code/nodejs-dns/node_modules/@google-cloud/common/src/util.ts:624:45)
    at onAuthenticated (/Users/beckwith/Code/nodejs-dns/node_modules/@google-cloud/common/src/util.ts:565:24)
    at /Users/beckwith/Code/nodejs-dns/node_modules/@google-cloud/common/src/util.ts:577:15
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:39906) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:39906) UnhandledPromiseRejectionWarning: TypeError: config.request.defaults is not a function
    at Util.makeRequest (/Users/beckwith/Code/nodejs-dns/node_modules/@google-cloud/common/src/util.ts:624:45)
    at onAuthenticated (/Users/beckwith/Code/nodejs-dns/node_modules/@google-cloud/common/src/util.ts:565:24)
    at /Users/beckwith/Code/nodejs-dns/node_modules/@google-cloud/common/src/util.ts:577:15
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:39906) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
^CTerminated: 15
```

Is this a bug in nodejs-common?  Or am I doing something wrong here?