### PR TITLE
chore(deps): update dependency @google-cloud/common to ^0.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "system-test": "mocha system-test/*.js --timeout 600000"
   },
   "dependencies": {
-    "@google-cloud/common": "^0.22.0",
+    "@google-cloud/common": "^0.23.0",
     "@google-cloud/paginator": "^0.1.0",
     "@google-cloud/promisify": "^0.3.0",
     "arrify": "^1.0.1",
@@ -64,6 +64,7 @@
     "lodash.groupby": "^4.6.0",
     "methmeth": "^1.1.0",
     "propprop": "^0.3.1",
+    "request": "^2.88.0",
     "string-format-obj": "^1.1.1"
   },
   "devDependencies": {

--- a/src/change.js
+++ b/src/change.js
@@ -16,6 +16,7 @@
 
 'use strict';
 
+const request = require('request');
 const {ServiceObject} = require('@google-cloud/common');
 const {promisifyAll} = require('@google-cloud/promisify');
 
@@ -179,6 +180,7 @@ class Change extends ServiceObject {
        */
       id: id,
       methods: methods,
+      requestModule: request,
     });
   }
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const {paginator} = require('@google-cloud/paginator');
 const {promisifyAll} = require('@google-cloud/promisify');
 const extend = require('extend');
 const is = require('is');
-const util = require('util');
+const request = require('request');
 
 const Zone = require('./zone');
 
@@ -89,6 +89,7 @@ class DNS extends Service {
         'https://www.googleapis.com/auth/cloud-platform',
       ],
       packageJson: require('../package.json'),
+      requestModule: request,
     };
     super(config, options);
   }
@@ -274,8 +275,6 @@ class DNS extends Service {
     return new Zone(this, name);
   }
 }
-
-util.inherits(DNS, Service);
 
 /**
  * Get {@link Zone} objects for all of the zones in your project as

--- a/src/zone.js
+++ b/src/zone.js
@@ -27,6 +27,7 @@ const fs = require('fs');
 const groupBy = require('lodash.groupby');
 const is = require('is');
 const prop = require('propprop');
+const request = require('request');
 const zonefile = require('dns-zonefile');
 
 const Change = require('./change');
@@ -211,6 +212,7 @@ class Zone extends ServiceObject {
       id: name,
       createMethod: dns.createZone.bind(dns),
       methods: methods,
+      requestModule: request,
     });
     /**
      * @name Zone#name


### PR DESCRIPTION
Supersedes https://github.com/googleapis/nodejs-dns/pull/91

Update common without changing the underlying HTTP dependency. We can use `teeny` in a separate PR.