### PR TITLE
fix(DNS): Add post-promisify type overloads to DNS methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export interface DNSConfig extends GoogleAuthOptions {
 }
 
 export interface GetZonesCallback {
-  (err: Error|null, zones: Zone[]|null, nextQuery?: {}|null,
+  (err: Error|null, zones: Zone[]|null, nextQuery?: GetZonesRequest|null,
    apiResponse?: Response): void;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,8 +213,13 @@ class DNS extends Service {
    *   const apiResponse = data[1];
    * });
    */
+  createZone(name: string, config: CreateZoneRequest):
+      Promise<[Zone, Response]>;
   createZone(
-      name: string, config: CreateZoneRequest, callback?: GetZoneCallback) {
+      name: string, config: CreateZoneRequest, callback: GetZoneCallback): void;
+  createZone(
+      name: string, config: CreateZoneRequest,
+      callback?: GetZoneCallback): void|Promise<[Zone, Response]> {
     if (!name) {
       throw new Error('A zone name is required.');
     }
@@ -285,11 +290,14 @@ class DNS extends Service {
    *   const zones = data[0];
    * });
    */
+  getZones(query?: GetZonesRequest):
+      Promise<[Zone[], GetZonesRequest|null, Response]>;
   getZones(callback: GetZonesCallback): void;
   getZones(query: GetZonesRequest, callback: GetZonesCallback): void;
   getZones(
-      queryOrCallback: GetZonesRequest|GetZonesCallback,
-      callback?: GetZonesCallback): void {
+      queryOrCallback?: GetZonesRequest|GetZonesCallback,
+      callback?: GetZonesCallback):
+      void|Promise<[Zone[], GetZonesRequest|null, Response]> {
     const query = typeof queryOrCallback === 'object' ? queryOrCallback : {};
     callback =
         typeof queryOrCallback === 'function' ? queryOrCallback : callback;
@@ -308,7 +316,7 @@ class DNS extends Service {
             zoneInstance.metadata = zone;
             return zoneInstance;
           });
-          let nextQuery: {}|null = null;
+          let nextQuery: GetZonesRequest|null = null;
           if (resp.nextPageToken) {
             nextQuery = extend({}, query, {
               pageToken: resp.nextPageToken,

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,8 @@ export interface GetZonesCallback {
    apiResponse?: Response): void;
 }
 
+export type GetZonesResponse = [Zone[], GetZonesRequest | null, Response];
+
 export interface GetZoneCallback {
   (err: Error|null, zone?: Zone|null, apiResponse?: Response): void;
 }
@@ -52,6 +54,8 @@ export interface CreateZoneRequest {
   description?: string;
   name?: string;
 }
+
+export type CreateZoneResponse = [Zone, Response];
 
 /**
  * @typedef {object} ClientConfig
@@ -215,12 +219,12 @@ class DNS extends Service {
    * });
    */
   createZone(name: string, config: CreateZoneRequest):
-      Promise<[Zone, Response]>;
+      Promise<CreateZoneResponse>;
   createZone(
       name: string, config: CreateZoneRequest, callback: GetZoneCallback): void;
   createZone(
       name: string, config: CreateZoneRequest,
-      callback?: GetZoneCallback): void|Promise<[Zone, Response]> {
+      callback?: GetZoneCallback): void|Promise<CreateZoneResponse> {
     if (!name) {
       throw new Error('A zone name is required.');
     }
@@ -291,14 +295,12 @@ class DNS extends Service {
    *   const zones = data[0];
    * });
    */
-  getZones(query?: GetZonesRequest):
-      Promise<[Zone[], GetZonesRequest|null, Response]>;
+  getZones(query?: GetZonesRequest): Promise<GetZonesResponse>;
   getZones(callback: GetZonesCallback): void;
   getZones(query: GetZonesRequest, callback: GetZonesCallback): void;
   getZones(
       queryOrCallback?: GetZonesRequest|GetZonesCallback,
-      callback?: GetZonesCallback):
-      void|Promise<[Zone[], GetZonesRequest|null, Response]> {
+      callback?: GetZonesCallback): void|Promise<GetZonesResponse> {
     const query = typeof queryOrCallback === 'object' ? queryOrCallback : {};
     callback =
         typeof queryOrCallback === 'function' ? queryOrCallback : callback;


### PR DESCRIPTION
This PR adds promisified overloads for `DNS` async methods `getZones` and `createZone`.
- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
