### PR TITLE
improvement: Remove "prettier" from "npm run fix"

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "system-test": "mocha build/system-test --timeout 600000",
     "clean": "gts clean",
     "compile": "tsc -p .",
-    "fix": "eslint --fix 'samples/**/*.js' && prettier --write samples/*.js samples/*/*.js && gts fix",
+    "fix": "eslint --fix 'samples/**/*.js' && gts fix",
     "prepare": "npm run compile",
     "pretest": "npm run compile"
   },


### PR DESCRIPTION
[Our eslint configuration](https://github.com/googleapis/nodejs-dns/blob/00d3101c5e8f1e1444c5a38da46bb73c8be6f029/.eslintrc.yml) already reports "prettier" diffs as errors via [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier). These diffs are all auto-fixable by `eslint --fix`. Therefore there's no need to call the `prettier` CLI command.