### PR TITLE
docs: First argument of Zone#create is required

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -189,7 +189,7 @@ class DNS extends Service {
    * @throws {error} If a zone dnsName is not provided.
    *
    * @param {string} name Name of the zone to create, e.g. "my-zone".
-   * @param {CreateZoneRequest} [config] Config to set for the zone.
+   * @param {CreateZoneRequest} config Config to set for the zone.
    * @param {CreateZoneCallback} [callback] Callback function.
    * @returns {Promise<CreateZoneResponse>}
    * @throws {Error} If a name is not provided.

--- a/src/zone.ts
+++ b/src/zone.ts
@@ -185,7 +185,7 @@ class Zone extends ServiceObject {
        * Create a zone.
        *
        * @method Zone#create
-       * @param {CreateZoneRequest} [metadata] Metadata to set for the zone.
+       * @param {CreateZoneRequest} metadata Metadata to set for the zone.
        * @param {CreateZoneCallback} [callback] Callback function.
        * @returns {Promise<CreateZoneResponse>}
        *


### PR DESCRIPTION
The jsdocs for DNS#createZone and Zone#create currently indicate that `config`/`metadata` argument is optional. In fact [it is required](https://github.com/googleapis/nodejs-dns/blob/d07673159609f2240394cf2a75a734f9ff546b08/src/index.ts#L221). When this PR is merged, the jsdocs will indicate as much.