### PR TITLE
fix: use split dns google domain

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ class DNS extends Service {
   constructor(options?: GoogleAuthOptions) {
     options = options || {};
     const config = {
-      baseUrl: 'https://www.googleapis.com/dns/v1',
+      baseUrl: 'https://dns.googleapis.com/dns/v1',
       scopes: [
         'https://www.googleapis.com/auth/ndev.clouddns.readwrite',
         'https://www.googleapis.com/auth/cloud-platform',

--- a/test/index.ts
+++ b/test/index.ts
@@ -124,7 +124,7 @@ describe('DNS', () => {
 
       const calledWith = dns.calledWith_[0];
 
-      const baseUrl = 'https://www.googleapis.com/dns/v1';
+      const baseUrl = 'https://dns.googleapis.com/dns/v1';
       assert.strictEqual(calledWith.baseUrl, baseUrl);
       assert.deepStrictEqual(calledWith.scopes, [
         'https://www.googleapis.com/auth/ndev.clouddns.readwrite',


### PR DESCRIPTION
This modifies the base uri for API calls from `https://www.googleapis.com/dns/v1` to `https://dns.googleapis.com/dns/v1`

Just dipping my toes in the domain splitting waters to verify the domain is correct. 