### PR TITLE
feat: switch to dns endpoint (options.apiEndpoint is available if time is needed to migrate)

### DIFF
--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -1,7 +1,6 @@
 {
   "recurse": true,
   "skip": [
-    "https://codecov.io/gh/googleapis/",
-    "www.googleapis.com"
+    "https://codecov.io/gh/googleapis/"
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export type CreateZoneResponse = [Zone, Metadata];
 export interface DNSOptions extends GoogleAuthOptions {
   /**
    * The API endpoint of the service used to make requests.
-   * Defaults to `www.googleapis.com`.
+   * Defaults to `dns.googleapis.com`.
    */
   apiEndpoint?: string;
 }
@@ -127,7 +127,7 @@ export interface DNSOptions extends GoogleAuthOptions {
 class DNS extends Service {
   getZonesStream: (query: GetZonesRequest) => Stream;
   constructor(options: DNSOptions = {}) {
-    options.apiEndpoint = options.apiEndpoint || 'www.googleapis.com';
+    options.apiEndpoint = options.apiEndpoint || 'dns.googleapis.com';
     const config = {
       apiEndpoint: options.apiEndpoint,
       baseUrl: `https://${options.apiEndpoint}/dns/v1`,

--- a/test/index.ts
+++ b/test/index.ts
@@ -124,7 +124,7 @@ describe('DNS', () => {
 
       const calledWith = dns.calledWith_[0];
 
-      const baseUrl = 'https://www.googleapis.com/dns/v1';
+      const baseUrl = 'https://dns.googleapis.com/dns/v1';
       assert.strictEqual(calledWith.baseUrl, baseUrl);
       assert.deepStrictEqual(calledWith.scopes, [
         'https://www.googleapis.com/auth/ndev.clouddns.readwrite',


### PR DESCRIPTION
Switches from `www.googleapis.com` to `dns.googleapis.com`.