### PR TITLE
feat: add support for setting DNS Sec

### DIFF
--- a/samples/test/dns.test.js
+++ b/samples/test/dns.test.js
@@ -30,6 +30,9 @@ describe(__filename, () => {
     const projectId = await dns.getProjectId();
     await dns.createZone(zoneName, {
       dnsName: `${projectId}.appspot.com.`,
+      dnssecConfig: {
+        state: 'on',
+      },
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,39 @@ export interface CreateZoneRequest {
   dnsName: string;
   description?: string;
   name?: string;
+  dnssecConfig?: ManagedZoneDnsSecConfig;
+}
+
+export interface ManagedZoneDnsSecConfig {
+  /**
+   * Specifies parameters for generating initial DnsKeys for this ManagedZone. Can only be changed while the state is OFF.
+   */
+  defaultKeySpecs?: DnsKeySpec[];
+  kind?: string | null;
+  /**
+   * Specifies the mechanism for authenticated denial-of-existence responses. Can only be changed while the state is OFF.
+   */
+  nonExistence?: string | null;
+  /**
+   * Specifies whether DNSSEC is enabled, and what mode it is in.
+   */
+  state?: 'on' | 'off' | null;
+}
+
+export interface DnsKeySpec {
+  /**
+   * String mnemonic specifying the DNSSEC algorithm of this key.
+   */
+  algorithm?: string | null;
+  /**
+   * Length of the keys in bits.
+   */
+  keyLength?: number | null;
+  /**
+   * Specifies whether this is a key signing key (KSK) or a zone signing key (ZSK). Key signing keys have the Secure Entry Point flag set and, when active, will only be used to sign resource record sets of type DNSKEY. Zone signing keys do not have the Secure Entry Point flag set and will be used to sign all other types of resource record sets.
+   */
+  keyType?: string | null;
+  kind?: string | null;
 }
 
 export type CreateZoneResponse = [Zone, Metadata];

--- a/test/change.ts
+++ b/test/change.ts
@@ -21,8 +21,6 @@ import * as promisify from '@google-cloud/promisify';
 import * as assert from 'assert';
 import {describe, it, before, beforeEach} from 'mocha';
 import * as proxyquire from 'proxyquire';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import {Change} from '../src/change';
 
 let promisified = false;
@@ -73,6 +71,7 @@ describe('Change', () => {
     it('should inherit from ServiceObject', () => {
       assert(change instanceof ServiceObject);
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const calledWith = (change as any).calledWith_[0];
 
       assert.strictEqual(calledWith.parent, ZONE);

--- a/test/index.ts
+++ b/test/index.ts
@@ -123,6 +123,7 @@ describe('DNS', () => {
     it('should inherit from Service', () => {
       assert(dns instanceof Service);
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const calledWith = (dns as any).calledWith_[0];
 
       const baseUrl = 'https://dns.googleapis.com/dns/v1';

--- a/test/zone.ts
+++ b/test/zone.ts
@@ -166,6 +166,7 @@ describe('Zone', () => {
       const zone = new Zone(dnsInstance, ZONE_NAME);
       assert(zone instanceof ServiceObject);
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const calledWith = (zone as any).calledWith_[0];
 
       assert.strictEqual(calledWith.parent, dnsInstance);


### PR DESCRIPTION
So @amanda-tarafa this was the easiest way to deal with the overground warnings, and it happens to be kinda nice for customers so 🤷  

